### PR TITLE
fix(parserOpts.noteKeywords): make the breaking change regex stricter

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var parserOpts = {
     'scope',
     'subject'
   ],
-  noteKeywords: 'BREAKING CHANGE',
+  noteKeywords: '^BREAKING CHANGE:',
   revertPattern: /^revert:\s([\s\S]*?)\s*This reverts commit (\w*)\./,
   revertCorrespondence: ['header', 'hash']
 };


### PR DESCRIPTION
The parser currently parses any occurrence of the string "breaking change" as breaking change. This is not in compliance with the Angular commit specs as it should look for a line starting with "BREAKING CHANGE:". I ran into this issue when trying to commit a non-breaking feature with the words "breaking changes" in the commit message.
