### PR TITLE
small edit to angular's style-guide, to better fit npm's goals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,3 @@
 ### Features
 
 * **init:** extracting code from https://github.com/ajoslin/conventional-changelog ([79a8c6b](https://github.com/stevemao/conventional-changelog-angular/commit/79a8c6b))
-
-
-

--- a/convention.md
+++ b/convention.md
@@ -44,9 +44,6 @@ A commit message consists of a **header**, **body** and **footer**.  The header 
 
 The **header** is mandatory and the **scope** of the header is optional.
 
-Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
-to read on GitHub as well as in various git tools.
-
 ### Revert
 
 If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit. In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted.

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ var writerOpts = {
     }
 
     if (typeof commit.subject === 'string') {
-      commit.subject = commit.subject.substring(0, 80);
+      commit.subject = commit.subject;
     }
 
     return commit;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "conventional-changelog-angular",
+  "name": "conventional-changelog-standard",
   "version": "1.0.0",
-  "description": "conventional-changelog angular preset",
+  "description": "conventional-changelog standard preset",
   "main": "index.js",
   "scripts": {
     "coverage": "istanbul cover -x test.js _mocha -- -R spec --timeout 30000 && rm -rf ./coverage",
@@ -10,19 +10,19 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stevemao/conventional-changelog-angular.git"
+    "url": "git+https://github.com/bcoe/conventional-changelog-standard.git"
   },
   "keywords": [
     "conventional-changelog",
-    "angular",
+    "standard",
     "preset"
   ],
   "author": "Steve Mao",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/stevemao/conventional-changelog-angular/issues"
+    "url": "https://github.com/bcoe/conventional-changelog-standard/issues"
   },
-  "homepage": "https://github.com/stevemao/conventional-changelog-angular#readme",
+  "homepage": "https://github.com/bcoe/conventional-changelog-standard#readme",
   "devDependencies": {
     "chai": "^3.4.1",
     "conventional-changelog-core": "^1.0.1",

--- a/readme.md
+++ b/readme.md
@@ -1,18 +1,17 @@
 #  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
 
-> [conventional-changelog](https://github.com/ajoslin/conventional-changelog) [angular](https://github.com/angular/angular) preset
-
+> The opinionated [conventional-changelog](https://github.com/ajoslin/conventional-changelog) preset, used by `standard-version`.
 
 See [convention](convention.md)
 
 **Issues with the convention itself should be reported on the angular issue tracker.**
 
 
-[npm-image]: https://badge.fury.io/js/conventional-changelog-angular.svg
-[npm-url]: https://npmjs.org/package/conventional-changelog-angular
-[travis-image]: https://travis-ci.org/stevemao/conventional-changelog-angular.svg?branch=master
-[travis-url]: https://travis-ci.org/stevemao/conventional-changelog-angular
-[daviddm-image]: https://david-dm.org/stevemao/conventional-changelog-angular.svg?theme=shields.io
-[daviddm-url]: https://david-dm.org/stevemao/conventional-changelog-angular
-[coveralls-image]: https://coveralls.io/repos/stevemao/conventional-changelog-angular/badge.svg
-[coveralls-url]: https://coveralls.io/r/stevemao/conventional-changelog-angular
+[npm-image]: https://badge.fury.io/js/conventional-changelog-standard.svg
+[npm-url]: https://npmjs.org/package/conventional-changelog-standard
+[travis-image]: https://travis-ci.org/bcoe/conventional-changelog-standard.svg?branch=master
+[travis-url]: https://travis-ci.org/bcoe/conventional-changelog-standard
+[daviddm-image]: https://david-dm.org/bcoe/conventional-changelog-standard.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/bcoe/conventional-changelog-standard
+[coveralls-image]: https://coveralls.io/repos/bcoe/conventional-changelog-standard/badge.svg
+[coveralls-url]: https://coveralls.io/r/bcoe/conventional-changelog-standard


### PR DESCRIPTION
@ceejbot @nexdrew fork of angular's commit format that lifts the restrictions on commit message size. I'm of the opinion that this is the right thing to do, and I'm building an opinionated library!

This will allow us to annotate our commits with `feat:`, `fix:`, `feat: BREAKING CHANGE:`, but other than that we can have as verbose and descriptive of commit messages as we desire.
