### PR TITLE
Merge conventional-changelog-standard back to this

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.2.0"></a>
+# [1.2.0](https://github.com/bcoe/conventional-changelog-standard/compare/v1.1.0...v1.2.0) (2016-04-09)
+
+
+### Features
+
+* **github:** adds github-specific replacements for issues and users ([ee703a3](https://github.com/bcoe/conventional-changelog-standard/commit/ee703a3))
+
+
+
 <a name="1.1.0"></a>
 # [1.1.0](https://github.com/bcoe/conventional-changelog-standard/compare/v1.0.0...v1.1.0) (2016-04-09)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+<a name="1.1.0"></a>
+# [1.1.0](https://github.com/bcoe/conventional-changelog-standard/compare/v1.0.0...v1.1.0) (2016-04-09)
+
+
+### Features
+
+* remove commit length restriction from angular's style-guide (this better fit's npm's workflow, the only thing blocking buy-in on standard commit messages). ([61da424](https://github.com/bcoe/conventional-changelog-standard/commit/61da424))
+
+
+
 <a name="1.0.0"></a>
 # [1.0.0](https://github.com/stevemao/conventional-changelog-angular/compare/v0.1.0...v1.0.0) (2016-02-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,3 @@
 ### Features
 
 * **init:** extracting code from https://github.com/ajoslin/conventional-changelog ([79a8c6b](https://github.com/stevemao/conventional-changelog-angular/commit/79a8c6b))
-
-
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="1.2.1"></a>
+## [1.2.1](https://github.com/bcoe/conventional-changelog-standard/compare/v1.2.0...v1.2.1) (2016-04-09)
+
+
+### Bug Fixes
+
+* loosen regex slightly ([bf10511](https://github.com/bcoe/conventional-changelog-standard/commit/bf10511))
+
+
+
 <a name="1.2.0"></a>
 # [1.2.0](https://github.com/bcoe/conventional-changelog-standard/compare/v1.1.0...v1.2.0) (2016-04-09)
 

--- a/convention.md
+++ b/convention.md
@@ -44,9 +44,6 @@ A commit message consists of a **header**, **body** and **footer**.  The header 
 
 The **header** is mandatory and the **scope** of the header is optional.
 
-Any line of the commit message cannot be longer 100 characters! This allows the message to be easier
-to read on GitHub as well as in various git tools.
-
 ### Revert
 
 If the commit reverts a previous commit, it should begin with `revert: `, followed by the header of the reverted commit. In the body it should say: `This reverts commit <hash>.`, where the hash is the SHA of the commit being reverted.

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ var writerOpts = {
     }
 
     if (typeof commit.subject === 'string') {
-      commit.subject = commit.subject.substring(0, 80);
+      commit.subject = commit.subject;
     }
 
     return commit;

--- a/index.js
+++ b/index.js
@@ -3,6 +3,17 @@ var compareFunc = require('compare-func');
 var Q = require('q');
 var readFile = Q.denodeify(require('fs').readFile);
 var resolve = require('path').resolve;
+var path = require('path');
+var pkgJson = {};
+var gufg = require('github-url-from-git');
+try {
+  pkgJson = require(path.resolve(
+    process.cwd(),
+    './package.json'
+  ));
+} catch (err) {
+  console.error('no root package.json found');
+}
 
 var parserOpts = {
   headerPattern: /^(\w*)(?:\((.*)\))?\: (.*)$/,
@@ -15,6 +26,19 @@ var parserOpts = {
   revertPattern: /^revert:\s([\s\S]*?)\s*This reverts commit (\w*)\./,
   revertCorrespondence: ['header', 'hash']
 };
+
+function issueUrl() {
+  var url = null;
+  if (pkgJson.repository && pkgJson.repository.url && ~pkgJson.repository.url.indexOf('github.com')) {
+    var gitUrl = gufg(pkgJson.repository.url);
+
+    if (gitUrl) {
+      return gitUrl + '/issues/';
+    } else {
+      return url;
+    }
+  }
+}
 
 var writerOpts = {
   transform: function(commit) {
@@ -56,6 +80,13 @@ var writerOpts = {
     }
 
     if (typeof commit.subject === 'string') {
+      var url = issueUrl();
+      if (url) {
+        // GitHub issue URLs.
+        commit.subject = commit.subject.replace(/( ?)#([0-9]+)(\b|^)/g, '$1[#$2](' + url + '$2)$3');
+      }
+      // GitHub user URLs.
+      commit.subject = commit.subject.replace(/( ?)@([a-zA-Z0-9]+)(\b|^)/g, '$1[@$2](https://github.com/$2)$3');
       commit.subject = commit.subject;
     }
 
@@ -75,6 +106,7 @@ module.exports = Q.all([
   readFile(resolve(__dirname, 'templates/footer.hbs'), 'utf-8')
 ])
   .spread(function(template, header, commit, footer) {
+
     writerOpts.mainTemplate = template;
     writerOpts.headerPartial = header;
     writerOpts.commitPartial = commit;

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ var writerOpts = {
         commit.subject = commit.subject.replace(/( ?)#([0-9]+)(\b|^)/g, '$1[#$2](' + url + '$2)$3');
       }
       // GitHub user URLs.
-      commit.subject = commit.subject.replace(/( ?)@([a-zA-Z0-9]+)(\b|^)/g, '$1[@$2](https://github.com/$2)$3');
+      commit.subject = commit.subject.replace(/( ?)@([a-zA-Z0-9_]+)(\b|^)/g, '$1[@$2](https://github.com/$2)$3');
       commit.subject = commit.subject;
     }
 

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "compare-func": "^1.3.1",
+    "github-url-from-git": "^1.4.0",
     "q": "^1.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conventional-changelog-standard",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "conventional-changelog standard preset",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conventional-changelog-standard",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "conventional-changelog standard preset",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "conventional-changelog-angular",
+  "name": "conventional-changelog-standard",
   "version": "1.0.0",
-  "description": "conventional-changelog angular preset",
+  "description": "conventional-changelog standard preset",
   "main": "index.js",
   "scripts": {
     "coverage": "istanbul cover -x test.js _mocha -- -R spec --timeout 30000 && rm -rf ./coverage",
@@ -10,19 +10,19 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/stevemao/conventional-changelog-angular.git"
+    "url": "git+https://github.com/bcoe/conventional-changelog-standard.git"
   },
   "keywords": [
     "conventional-changelog",
-    "angular",
+    "standard",
     "preset"
   ],
   "author": "Steve Mao",
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/stevemao/conventional-changelog-angular/issues"
+    "url": "https://github.com/bcoe/conventional-changelog-standard/issues"
   },
-  "homepage": "https://github.com/stevemao/conventional-changelog-angular#readme",
+  "homepage": "https://github.com/bcoe/conventional-changelog-standard#readme",
   "devDependencies": {
     "chai": "^3.4.1",
     "conventional-changelog-core": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conventional-changelog-standard",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "conventional-changelog standard preset",
   "main": "index.js",
   "scripts": {

--- a/readme.md
+++ b/readme.md
@@ -1,18 +1,17 @@
 #  [![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Coverage Status][coveralls-image]][coveralls-url]
 
-> [conventional-changelog](https://github.com/ajoslin/conventional-changelog) [angular](https://github.com/angular/angular) preset
-
+> The opinionated [conventional-changelog](https://github.com/ajoslin/conventional-changelog) preset, used by `standard-version`.
 
 See [convention](convention.md)
 
 **Issues with the convention itself should be reported on the angular issue tracker.**
 
 
-[npm-image]: https://badge.fury.io/js/conventional-changelog-angular.svg
-[npm-url]: https://npmjs.org/package/conventional-changelog-angular
-[travis-image]: https://travis-ci.org/stevemao/conventional-changelog-angular.svg?branch=master
-[travis-url]: https://travis-ci.org/stevemao/conventional-changelog-angular
-[daviddm-image]: https://david-dm.org/stevemao/conventional-changelog-angular.svg?theme=shields.io
-[daviddm-url]: https://david-dm.org/stevemao/conventional-changelog-angular
-[coveralls-image]: https://coveralls.io/repos/stevemao/conventional-changelog-angular/badge.svg
-[coveralls-url]: https://coveralls.io/r/stevemao/conventional-changelog-angular
+[npm-image]: https://badge.fury.io/js/conventional-changelog-standard.svg
+[npm-url]: https://npmjs.org/package/conventional-changelog-standard
+[travis-image]: https://travis-ci.org/bcoe/conventional-changelog-standard.svg?branch=master
+[travis-url]: https://travis-ci.org/bcoe/conventional-changelog-standard
+[daviddm-image]: https://david-dm.org/bcoe/conventional-changelog-standard.svg?theme=shields.io
+[daviddm-url]: https://david-dm.org/bcoe/conventional-changelog-standard
+[coveralls-image]: https://coveralls.io/repos/bcoe/conventional-changelog-standard/badge.svg
+[coveralls-url]: https://coveralls.io/r/bcoe/conventional-changelog-standard

--- a/test.js
+++ b/test.js
@@ -78,7 +78,7 @@ describe('angular preset', function() {
   });
 
   it('should replace @username with GitHub user URL', function(done) {
-    gitDummyCommit(['feat(awesome): issue brought up by @bcoe on Friday']);
+    gitDummyCommit(['feat(awesome): issue brought up by @bcoe! on Friday']);
 
     conventionalChangelogCore({
       config: preset

--- a/test.js
+++ b/test.js
@@ -61,6 +61,38 @@ describe('angular preset', function() {
       }));
   });
 
+  it('should replace #[0-9]+ with GitHub issue URL', function(done) {
+    gitDummyCommit(['feat(awesome): addresses the issue brought up in #133']);
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function(err) {
+        done(err);
+      })
+      .pipe(through(function(chunk) {
+        chunk = chunk.toString();
+        expect(chunk).to.include('[#133](https://github.com/bcoe/conventional-changelog-standard/issues/133)');
+        done();
+      }));
+  });
+
+  it('should replace @username with GitHub user URL', function(done) {
+    gitDummyCommit(['feat(awesome): issue brought up by @bcoe on Friday']);
+
+    conventionalChangelogCore({
+      config: preset
+    })
+      .on('error', function(err) {
+        done(err);
+      })
+      .pipe(through(function(chunk) {
+        chunk = chunk.toString();
+        expect(chunk).to.include('[@bcoe](https://github.com/bcoe)');
+        done();
+      }));
+  });
+
   it('should not discard commit if there is BREAKING CHANGE', function(done) {
     gitDummyCommit(['docs(readme): make it clear', 'BREAKING CHANGE: The Change is huge.']);
     gitDummyCommit(['style(whitespace): make it easier to read', 'BREAKING CHANGE: The Change is huge.']);


### PR DESCRIPTION
Hi @bcoe , I want to merge conventional-changelog-standard to this. I think all the commits can be merged. 

One small thing is the previously all references are worded like this

```
Closes #1 #2
```

Even if the commit is like 

```
Fixes #1, Resolved #2
```

Now if `#1` appears it will be replaced by a link.

I don't think this is a problem but maybe I'll change my mind later (move it to core or something) 😜 

Is there anything you wanna add here?
