### PR TITLE
fix(bitbucket): Correct header template for Bitbucket

### DIFF
--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -17,7 +17,7 @@
     {{~@root.repoUrl}}
   {{~/if~}}
   {{~#if @root.host~}}
-    {{~#if @root.host_bitbucket~}} {{~!-- BitBucket makes the comparision with two dots --}}
+    {{~#if @root.host_bitbucket~}} {{~!-- BitBucket makes the comparision with two dots --~}}
       /compare/{{previousTag}}..{{currentTag}})
     {{~else~}}
       /compare/{{previousTag}}...{{currentTag}})

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -1,4 +1,10 @@
-<a name="{{version}}"></a>
+{{~#if @root.host~}}
+  {{~#ifCond @root.host "regex" "github|gitlab" "i" ~}} {{~!-- BitBucket does not support html --~}}
+    <a name="{{version}}"></a>
+  {{~/ifCond~}}
+{{~else~}}
+  <a name="{{version}}"></a>
+{{~/if~}}
 {{#if isPatch~}}
   ##
 {{~else~}}
@@ -17,11 +23,11 @@
     {{~@root.repoUrl}}
   {{~/if~}}
   {{~#if @root.host~}}
-    {{~#if @root.host_bitbucket~}} {{~!-- BitBucket makes the comparision with two dots --~}}
+    {{~#ifCond @root.host "regex" "bitbucket" "i" ~}} {{~!-- BitBucket makes the comparision with two dots --~}}
       /compare/{{previousTag}}..{{currentTag}})
     {{~else~}}
       /compare/{{previousTag}}...{{currentTag}})
-    {{~/if~}}
+    {{~/ifCond~}}
   {{~else~}}
     /compare/{{previousTag}}...{{currentTag}})
   {{~/if~}}

--- a/templates/header.hbs
+++ b/templates/header.hbs
@@ -16,7 +16,15 @@
   {{~else}}
     {{~@root.repoUrl}}
   {{~/if~}}
-  /compare/{{previousTag}}...{{currentTag}})
+  {{~#if @root.host~}}
+    {{~#if @root.host_bitbucket~}} {{~!-- BitBucket makes the comparision with two dots --}}
+      /compare/{{previousTag}}..{{currentTag}})
+    {{~else~}}
+      /compare/{{previousTag}}...{{currentTag}})
+    {{~/if~}}
+  {{~else~}}
+    /compare/{{previousTag}}...{{currentTag}})
+  {{~/if~}}
 {{~else}}
   {{~version}}
 {{~/if}}

--- a/test/test.js
+++ b/test/test.js
@@ -228,4 +228,30 @@ describe('angular preset', function() {
         done();
       }));
   });
+  
+  it('should work for Bitbucket', function(done) {
+    preparing(8);
+    var i = 0;
+
+    conventionalChangelogCore({
+      config: preset
+    }, {
+      host: 'https://bitbucket.org'
+    })
+      .on('error', function(err) {
+        done(err);
+      })
+      .pipe(through(function(chunk, enc, cb) {
+        chunk = chunk.toString();
+
+        expect(chunk).to.not.include('<a name');  // Bitbucket does not support HTML
+        expect(chunk).to.not.include('...');      // Bitbucket does not compare with '...'
+
+        i++;
+        cb();
+      }, function() {
+        expect(i).to.equal(1);
+        done();
+      }));
+  });
 });


### PR DESCRIPTION
As said on the comment:
Of the three host alloweds, bitbucket is the only one that makes the comparision with two dots, instead of three.
With this context property (to be added in a pull request within conventional-changelog-core), if we are passing a valid host, this will fix the comparision link for bitbucket users.
