### PR TITLE
update from angular 1x to angular 2x convention

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,26 +47,34 @@ var writerOpts = {
       discard = false;
     });
 
+    // Angular 2 commit conventions
+    // Link: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type
+    // added: build, ci
+
     if (commit.type === 'feat') {
       commit.type = 'Features';
     } else if (commit.type === 'fix') {
       commit.type = 'Bug Fixes';
-    } else if (commit.type === 'perf') {
-      commit.type = 'Performance Improvements';
-    } else if (commit.type === 'revert') {
-      commit.type = 'Reverts';
-    } else if (discard) {
-      return;
     } else if (commit.type === 'docs') {
       commit.type = 'Documentation';
     } else if (commit.type === 'style') {
       commit.type = 'Styles';
     } else if (commit.type === 'refactor') {
       commit.type = 'Code Refactoring';
+    } else if (commit.type === 'perf') {
+      commit.type = 'Performance Improvements';
     } else if (commit.type === 'test') {
       commit.type = 'Tests';
+    } else if (commit.type === 'build') {
+      commit.type = 'Build';
+    } else if (commit.type === 'ci') {
+      commit.type = 'Continuous Integration';
     } else if (commit.type === 'chore') {
       commit.type = 'Chores';
+    } else if (commit.type === 'revert') {
+      commit.type = 'Reverts';
+    } else if (discard) {
+      return;
     }
 
     if (commit.scope === '*') {

--- a/index.js
+++ b/index.js
@@ -47,10 +47,6 @@ var writerOpts = {
       discard = false;
     });
 
-    // Angular 2 commit conventions
-    // Link: https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type
-    // added: build, ci
-
     if (commit.type === 'feat') {
       commit.type = 'Features';
     } else if (commit.type === 'fix') {

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "homepage": "https://github.com/conventional-changelog/conventional-changelog-angular#readme",
   "devDependencies": {
     "better-than-before": "^1.0.0",
-    "chai": "^3.5.0",
+    "chai": "^4.1.0",
     "conventional-changelog-core": "^1.5.0",
     "coveralls": "^2.11.14",
     "git-dummy-commit": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conventional-changelog-angular",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "conventional-changelog angular preset",
   "main": "index.js",
   "scripts": {
@@ -25,19 +25,19 @@
   "homepage": "https://github.com/conventional-changelog/conventional-changelog-angular#readme",
   "devDependencies": {
     "better-than-before": "^1.0.0",
-    "chai": "^3.4.1",
-    "conventional-changelog-core": "^1.0.1",
-    "coveralls": "^2.11.6",
-    "git-dummy-commit": "^1.1.1",
-    "istanbul": "^0.4.1",
+    "chai": "^3.5.0",
+    "conventional-changelog-core": "^1.5.0",
+    "coveralls": "^2.11.14",
+    "git-dummy-commit": "^1.3.0",
+    "istanbul": "^0.4.5",
     "jscs": "^3.0.7",
-    "jshint": "^2.9.1",
+    "jshint": "^2.9.4",
     "mocha": "*",
-    "shelljs": "^0.7.3",
-    "through2": "^2.0.0"
+    "shelljs": "^0.7.5",
+    "through2": "^2.0.1"
   },
   "dependencies": {
-    "compare-func": "^1.3.1",
+    "compare-func": "^1.3.2",
     "github-url-from-git": "^1.4.0",
     "q": "^1.4.1"
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "devDependencies": {
     "better-than-before": "^1.0.0",
     "chai": "^4.1.0",
-    "conventional-changelog-core": "^1.5.0",
+    "conventional-changelog-core": "^2.0.0",
     "coveralls": "^2.11.14",
     "git-dummy-commit": "^1.3.0",
     "istanbul": "^0.4.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conventional-changelog-angular",
-  "version": "1.4.0",
+  "version": "1.3.0",
   "description": "conventional-changelog angular preset",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "conventional-changelog-angular",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "conventional-changelog angular preset",
   "main": "index.js",
   "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -23,6 +23,8 @@ betterThanBefore.setups([
     gitDummyCommit(['fix(compile): avoid a bug', 'BREAKING CHANGE: The Change is huge.']);
     gitDummyCommit(['perf(ngOptions): make it faster', ' closes #1, #2']);
     gitDummyCommit('revert(ngOptions): bad commit');
+    gitDummyCommit('build(npm): update dependencies');
+    gitDummyCommit('ci(travis): update travis configuration');
     gitDummyCommit('fix(*): oops');
   },
   function() {
@@ -74,9 +76,10 @@ describe('angular preset', function() {
         expect(chunk).to.include('Performance Improvements');
         expect(chunk).to.include('Reverts');
         expect(chunk).to.include('bad commit');
+        expect(chunk).to.include('update dependencies');
+        expect(chunk).to.include('update travis configuration');
         expect(chunk).to.include('BREAKING CHANGES');
 
-        expect(chunk).to.not.include('first commit');
         expect(chunk).to.not.include('feat');
         expect(chunk).to.not.include('fix');
         expect(chunk).to.not.include('perf');


### PR DESCRIPTION
### Update Information:

Update commit convention from [Angular 1x](https://github.com/angular/angular.js/blob/master/CONTRIBUTING.md#type) to [Angular 2x](https://github.com/angular/angular/blob/master/CONTRIBUTING.md#type).

 - **added: build + ci**

to be compatible with: [Commitizen conventional-commit-types](https://github.com/commitizen/conventional-commit-types/blob/master/index.json)

i also made a pull request yesterday which got through to [conventional-changelog-lint-config-angular](https://github.com/marionebl/conventional-changelog-lint-config-angular/pull/3) to fix lint errors with [conventional-changelog-lint](https://github.com/marionebl/conventional-changelog-lint).

example usage and boilerplate for beginners could be found here: [node-developer-boilerplate](https://github.com/ellerbrock/node-developer-boilerplate).

and thanks for your work. i forked your repo and added emoji support here: [conventional-changelog-angular-emoji](https://github.com/ellerbrock/conventional-changelog-angular-emoji)

have fun and happy hacking!

![woop woop](http://i.giphy.com/18pjPEqqIt2k8.gif)